### PR TITLE
add description dataSchema shorthand ajv property support

### DIFF
--- a/src/description.spec.ts
+++ b/src/description.spec.ts
@@ -85,7 +85,7 @@ describe('Description handler', function test() {
       );
     });
 
-    it.only('should reject invalid description', async () => {
+    it('should reject invalid description', async () => {
       const contract = await executor.createContract('Described', [], { from: accounts[0], gas: 1000000 });
       let descriptionEnvelope;
       let promise;

--- a/src/description.spec.ts
+++ b/src/description.spec.ts
@@ -85,7 +85,7 @@ describe('Description handler', function test() {
       );
     });
 
-    it('should reject invalid description', async () => {
+    it.only('should reject invalid description', async () => {
       const contract = await executor.createContract('Described', [], { from: accounts[0], gas: 1000000 });
       let descriptionEnvelope;
       let promise;
@@ -130,9 +130,30 @@ describe('Description handler', function test() {
       );
       await expect(promise).to.be.rejected;
 
-      // invalid dataSchema
+      // invalid ajv dataSchema
       descriptionEnvelope = { public: { ...sampleDescription } };
-      descriptionEnvelope.public.dataSchema = { type: 'text' };
+      descriptionEnvelope.public.dataSchema = {
+        properties: {
+          test: {
+            type: 'text',
+          },
+        },
+        type: 'object',
+      };
+      promise = description.setDescriptionToContract(
+        contract.options.address,
+        descriptionEnvelope,
+        accounts[0],
+      );
+      await expect(promise).to.be.rejected;
+
+      // invalid shorthand ajv dataSchema for multiple ajv schemas
+      descriptionEnvelope = { public: { ...sampleDescription } };
+      descriptionEnvelope.public.dataSchema = {
+        type: {
+          type: 'text',
+        },
+      };
       promise = description.setDescriptionToContract(
         contract.options.address,
         descriptionEnvelope,

--- a/src/description.ts
+++ b/src/description.ts
@@ -364,7 +364,7 @@ export class Description extends Logger {
     if (combinedDescription.dataSchema) {
       const schema = combinedDescription.dataSchema;
 
-      // if type is speecified as string on top level, check the full dataSchema (represents normal
+      // if type is specified as string on top level, check the full dataSchema (represents normal
       // ajv definition)
       if (typeof schema.type === 'string') {
         const schemaValidation = Validator.isSchemaCorrect(schema);

--- a/src/description.ts
+++ b/src/description.ts
@@ -373,9 +373,9 @@ export class Description extends Logger {
         }
       }
 
-      // else, shorthand dataSchema properties are defined. So do not check full dataSchema, instead iterate
-      // through all sub properties to check for entry schema validity. So that each entry can use any
-      // name without ajv reserved property restrictions.
+      // else, shorthand dataSchema properties are defined. So do not check full dataSchema, instead
+      // iterate through all sub properties to check for entry schema validity. So that each entry
+      // can use any name without ajv reserved property restrictions.
       const entries = Object.keys(schema);
       for (let i = 0; i < entries.length; i += 1) {
         const schemaValidation = Validator.isSchemaCorrect(schema[entries[i]]);

--- a/src/description.ts
+++ b/src/description.ts
@@ -374,7 +374,7 @@ export class Description extends Logger {
       }
 
       // else, shorthand dataSchema properties are defined. So do not check full dataSchema, instead iterate
-      // through all sub properties to check for entry schema validity, so each entry can use any
+      // through all sub properties to check for entry schema validity. So that each entry can use any
       // name without ajv reserved property restrictions.
       const entries = Object.keys(schema);
       for (let i = 0; i < entries.length; i += 1) {

--- a/src/description.ts
+++ b/src/description.ts
@@ -375,7 +375,7 @@ export class Description extends Logger {
 
       // else, shorthand dataSchema properties are defined. So do not check full dataSchema, instead iterate
       // through all sub properties to check for entry schema validity, so each entry can use any
-      // name without ajv reservd property restrictions.
+      // name without ajv reserved property restrictions.
       const entries = Object.keys(schema);
       for (let i = 0; i < entries.length; i += 1) {
         const schemaValidation = Validator.isSchemaCorrect(schema[entries[i]]);

--- a/src/description.ts
+++ b/src/description.ts
@@ -373,7 +373,7 @@ export class Description extends Logger {
         }
       }
 
-      // Else, shorthand dataschema properties are define, so do not check full dataSchema. Iterate
+      // else, shorthand dataSchema properties are defined. So do not check full dataSchema, instead iterate
       // through all sub properties to check for entry schema validity, so each entry can use any
       // name without ajv reservd property restrictions.
       const entries = Object.keys(schema);

--- a/src/description.ts
+++ b/src/description.ts
@@ -362,10 +362,26 @@ export class Description extends Logger {
     // if a dataSchema was attached to the description, check it's integrity, so no wrong types or
     // configuration values are passed.
     if (combinedDescription.dataSchema) {
-      const schemaValidation = Validator.isSchemaCorrect(combinedDescription.dataSchema);
+      const schema = combinedDescription.dataSchema;
 
-      if (schemaValidation !== true) {
-        return schemaValidation;
+      // if type is speecified as string on top level, check the full dataSchema (represents normal
+      // ajv definition)
+      if (typeof schema.type === 'string') {
+        const schemaValidation = Validator.isSchemaCorrect(schema);
+        if (schemaValidation !== true) {
+          return schemaValidation;
+        }
+      }
+
+      // Else, shorthand dataschema properties are define, so do not check full dataSchema. Iterate
+      // through all sub properties to check for entry schema validity, so each entry can use any
+      // name without ajv reservd property restrictions.
+      const entries = Object.keys(schema);
+      for (let i = 0; i < entries.length; i += 1) {
+        const schemaValidation = Validator.isSchemaCorrect(schema[entries[i]]);
+        if (schemaValidation !== true) {
+          return schemaValidation;
+        }
       }
     }
 

--- a/src/description.ts
+++ b/src/description.ts
@@ -359,7 +359,7 @@ export class Description extends Logger {
       return descValidation;
     }
 
-    // if a dataSchema was attached to the description, check it's integrity, so no wrong types or
+    // if a dataSchema was attached to the description, check its integrity, so no wrong types or
     // configuration values are passed.
     if (combinedDescription.dataSchema) {
       const schema = combinedDescription.dataSchema;


### PR DESCRIPTION
- `@evan.network/api-blockchain-core` `Container` API breaks because of top level dataSchema property `type`
- [CORE-944]

[CORE-944]: https://evannetwork.atlassian.net/browse/CORE-944